### PR TITLE
Enable iOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,21 @@ In the project directory, you can run:
 
 - `npm run dev` or `yarn dev` - Starts the development server
 - `npm run build:web` or `yarn build:web` - Builds the app for web deployment
+- `npm run build:ios` or `yarn build:ios` - Generates a production iOS build
 - `npm run lint` or `yarn lint` - Runs the linter to check for code issues
+
+### Building for iOS
+
+Use the provided script to generate an iOS build with EAS:
+
+```bash
+npm run build:ios
+```
+
+This command uploads the project to Expo Application Services and generates an
+`.ipa` file you can submit to TestFlight or the App Store. Ensure you have set
+up your Apple developer credentials with `eas credentials` before running the
+build.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
+    "build:ios": "eas build --platform ios --profile production",
     "lint": "expo lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `build:ios` npm script
- document how to create iOS build with EAS

## Testing
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c4e30dc6c8320999c59ab11f25f62